### PR TITLE
fix email missing when logging in with operator

### DIFF
--- a/src/MeliSocialite.php
+++ b/src/MeliSocialite.php
@@ -81,7 +81,7 @@ class MeliSocialite extends AbstractProvider implements ProviderInterface
             'id'                => $user['id'],
             'nickname'          => $user['nickname'],
             'name'              => trim($user['first_name'].' '.$user['last_name']),
-            'email'             => $user['email'],
+            'email'             => (isset($user['email']))? $user['email'] : \Auth::user()->email,
         ]);
     }
 
@@ -117,7 +117,7 @@ class MeliSocialite extends AbstractProvider implements ProviderInterface
     {
         return $this->parsed_response['expires_in'];
     }
-    
+
     public function user()
     {
         if ($this->hasInvalidState()) {


### PR DESCRIPTION
When logging in with a MercadoLibre operator (and not a user), there is no email in the response from ML, so you get an "Invalid index 'email'" error. With this fix you can login using both a user or an operator.